### PR TITLE
Return a promise from transformStream shim

### DIFF
--- a/lib/ece.js
+++ b/lib/ece.js
@@ -79,11 +79,12 @@ export function encryptStream (
   const stream = transformStream(
     input,
     new SliceTransformer(rs - TAG_LENGTH - 1)
-  )
+  ).readable
+
   return transformStream(
     stream,
     new ECETransformer(MODE_ENCRYPT, secretKey, rs, salt)
-  )
+  ).readable
 }
 
 /**
@@ -94,11 +95,12 @@ export function encryptStream (
  * rs:        int containing record size, optional
  */
 export function decryptStream (input, secretKey, rs = RECORD_SIZE) {
-  const stream = transformStream(input, new SliceTransformer(HEADER_LENGTH, rs))
+  const stream = transformStream(input, new SliceTransformer(HEADER_LENGTH, rs)).readable
+
   return transformStream(
     stream,
     new ECETransformer(MODE_DECRYPT, secretKey, rs)
-  )
+  ).readable
 }
 
 function checkSecretKey (secretKey) {

--- a/lib/transform-stream.js
+++ b/lib/transform-stream.js
@@ -2,30 +2,62 @@
 /* global TransformStream */
 
 /**
- * Pipe a readable stream through a transformer. Return the readable end of the
- * TransformStream.
+ * Pipe a readable stream through a transformer. Returns a result, where
+ * result.readable is the readable end of the TransformStream and
+ * result.done is a promise that fulfills or rejects once the stream is done.
  * Includes a shim for environments where TransformStream is not available.
  */
-export function transformStream (readable, transformer) {
-  // Chrome, Edge, Safari TP
+export function transformStream (sourceReadable, transformer) {
+  let transformedReadable
+  let done
+
   if (typeof TransformStream !== 'undefined') {
-    return readable.pipeThrough(new TransformStream(transformer))
+    // Chrome, Edge, Safari TP
+    const transform = new TransformStream(transformer)
+
+    done = sourceReadable.pipeTo(transform.writable)
+    transformedReadable = transform.readable
+  } else {
+    // Firefox, Safari 14 and older
+    let doneCb = null
+
+    done = new Promise((resolve, reject) => {
+      doneCb = (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      }
+    })
+    transformedReadable = new ReadableStream(new TransformStreamSource(sourceReadable, transformer, doneCb))
   }
 
-  // Firefox, Safari 14 and older
-  return new ReadableStream(new TransformStreamSource(readable, transformer))
+  // Ensure the caller doesn't need to catch errors
+  done.catch(() => {})
+
+  return {
+    readable: transformedReadable,
+    done
+  }
 }
 
 class TransformStreamSource {
-  constructor (readable, transformer) {
+  constructor (readable, transformer, doneCb) {
     this.readable = readable
     this.transformer = transformer
+    this.doneCb = doneCb
     this.reader = readable.getReader()
   }
 
   async start (controller) {
     if (this.transformer.start) {
-      return await this.transformer.start(controller)
+      try {
+        return await this.transformer.start(controller)
+      } catch (err) {
+        this.doneCb(err)
+        throw err
+      }
     }
   }
 
@@ -40,23 +72,35 @@ class TransformStreamSource {
 
     // eslint-disable-next-line no-unmodified-loop-condition
     while (!enqueued) {
-      const data = await this.reader.read()
-      if (data.done) {
-        if (this.transformer.flush) {
-          await this.transformer.flush(controller)
+      try {
+        const data = await this.reader.read()
+        if (data.done) {
+          if (this.transformer.flush) {
+            await this.transformer.flush(controller)
+          }
+          controller.close()
+          this.doneCb(null)
+          return
         }
-        controller.close()
-        return
-      }
-      if (this.transformer.transform) {
-        await this.transformer.transform(data.value, wrappedController)
-      } else {
-        wrappedController.enqueue(data.value)
+        if (this.transformer.transform) {
+          await this.transformer.transform(data.value, wrappedController)
+        } else {
+          wrappedController.enqueue(data.value)
+        }
+      } catch (err) {
+        this.doneCb(err)
+        throw err
       }
     }
   }
 
   async cancel (reason) {
-    return await this.reader.cancel(reason)
+    await this.reader.cancel(reason)
+    if (reason instanceof Error) {
+      this.doneCb(reason)
+    } else {
+      this.doneCb(new Error(`stream cancelled; reason: ${reason}`))
+    }
+    return reason
   }
 }

--- a/lib/transform-stream.js
+++ b/lib/transform-stream.js
@@ -51,7 +51,7 @@ class TransformStreamSource {
   }
 
   async start (controller) {
-    if (this.transformer.start) {
+    if (this.transformer?.start) {
       try {
         return await this.transformer.start(controller)
       } catch (err) {
@@ -75,14 +75,14 @@ class TransformStreamSource {
       try {
         const data = await this.reader.read()
         if (data.done) {
-          if (this.transformer.flush) {
+          if (this.transformer?.flush) {
             await this.transformer.flush(controller)
           }
           controller.close()
           this.doneCb(null)
           return
         }
-        if (this.transformer.transform) {
+        if (this.transformer?.transform) {
           await this.transformer.transform(data.value, wrappedController)
         } else {
           wrappedController.enqueue(data.value)

--- a/lib/transform-stream.js
+++ b/lib/transform-stream.js
@@ -19,18 +19,13 @@ export function transformStream (sourceReadable, transformer) {
     transformedReadable = transform.readable
   } else {
     // Firefox, Safari 14 and older
-    let doneCb = null
-
+    let resolveDone
+    let rejectDone
     done = new Promise((resolve, reject) => {
-      doneCb = (err) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
-      }
+      resolveDone = resolve
+      rejectDone = reject
     })
-    transformedReadable = new ReadableStream(new TransformStreamSource(sourceReadable, transformer, doneCb))
+    transformedReadable = new ReadableStream(new TransformStreamSource(sourceReadable, transformer, { resolveDone, rejectDone }))
   }
 
   // Ensure the caller doesn't need to catch errors
@@ -43,19 +38,20 @@ export function transformStream (sourceReadable, transformer) {
 }
 
 class TransformStreamSource {
-  constructor (readable, transformer, doneCb) {
+  constructor (readable, transformer, { resolveDone, rejectDone }) {
     this.readable = readable
     this.transformer = transformer
-    this.doneCb = doneCb
+    this.resolveDone = resolveDone
+    this.rejectDone = rejectDone
     this.reader = readable.getReader()
   }
 
   async start (controller) {
     if (this.transformer?.start) {
       try {
-        return await this.transformer.start(controller)
+        await this.transformer.start(controller)
       } catch (err) {
-        this.doneCb(err)
+        this.rejectDone(err)
         throw err
       }
     }
@@ -79,7 +75,7 @@ class TransformStreamSource {
             await this.transformer.flush(controller)
           }
           controller.close()
-          this.doneCb(null)
+          this.resolveDone()
           return
         }
         if (this.transformer?.transform) {
@@ -88,7 +84,7 @@ class TransformStreamSource {
           wrappedController.enqueue(data.value)
         }
       } catch (err) {
-        this.doneCb(err)
+        this.rejectDone(err)
         throw err
       }
     }
@@ -97,10 +93,9 @@ class TransformStreamSource {
   async cancel (reason) {
     await this.reader.cancel(reason)
     if (reason instanceof Error) {
-      this.doneCb(reason)
+      this.rejectDone(reason)
     } else {
-      this.doneCb(new Error(`stream cancelled; reason: ${reason}`))
+      this.rejectDone(new Error(`stream cancelled; reason: ${reason}`))
     }
-    return reason
   }
 }

--- a/lib/transform-stream.js
+++ b/lib/transform-stream.js
@@ -12,7 +12,7 @@ export function transformStream (sourceReadable, transformer) {
   let done
 
   if (typeof TransformStream !== 'undefined') {
-    // Chrome, Edge, Safari TP
+    // Chrome, Edge, Safari 14.1+
     const transform = new TransformStream(transformer)
 
     done = sourceReadable.pipeTo(transform.writable)


### PR DESCRIPTION
This makes it possible to determine when a stream is done and whether it was successful, similar to the promise returned by native `ReadableStream.pipeTo`